### PR TITLE
handle run of trimmed whitespace

### DIFF
--- a/better_diff/unified_plus.py
+++ b/better_diff/unified_plus.py
@@ -1,5 +1,6 @@
 """A unified+ format based on the standard difflib.unified_diff."""
 
+import collections
 import difflib
 import typing
 
@@ -25,6 +26,8 @@ def format_diff(a: str, b: str, fromfile: str = "a", tofile: str = "b") -> str:
         normalized_endings_a += newline_difference_message * (len(a) - len(normalized_endings_a))
         normalized_endings_b += newline_difference_message * (len(b) - len(normalized_endings_b))
 
+    dangling_whitespace_run = collections.deque()
+
     for line in difflib.unified_diff(
         a=normalized_endings_a.splitlines(),
         b=normalized_endings_b.splitlines(),
@@ -42,12 +45,43 @@ def format_diff(a: str, b: str, fromfile: str = "a", tofile: str = "b") -> str:
                     new_line_is_last_line_without_whitespace,
                 ]
             ):
-                highlight = "^" * (len(last_line) - len(last_line.rstrip()))
-                result.append("?" + " " * (len(line) - 1) + highlight)
+                _highlight_dangling_whitespace(result, last_line, line)
+
+            elif dangling_whitespace_run and line.startswith("+"):
+                if line[1:].rstrip() == dangling_whitespace_run[0][1:].rstrip():
+                    old_line = dangling_whitespace_run.popleft()
+                    result.append(old_line)
+                    _highlight_dangling_whitespace(result, old_line, line)
+                    result.append(line)
+
+                    continue
+                else:
+                    _dump_dangling_whitespace_run(result, dangling_whitespace_run)
+
+            elif last_line_had_dangling_whitespace:
+                we_may_be_continuing = line.startswith("-")
+                if we_may_be_continuing:
+                    dangling_whitespace_run.append(line)
+                    continue  # don't print this one yet
+                else:
+                    _dump_dangling_whitespace_run(result, dangling_whitespace_run)
 
         result.append(line.rstrip())
         last_line = line
 
+    _dump_dangling_whitespace_run(result, dangling_whitespace_run)
+
     if not result:
         return ""
     return "\n".join(result) + "\n"
+
+
+def _highlight_dangling_whitespace(result, last_line, line):
+    highlight = "^" * (len(last_line) - len(last_line.rstrip()))
+    result.append("?" + " " * (len(line) - 1) + highlight)
+
+
+def _dump_dangling_whitespace_run(result: list, dangling_whitespace_run: collections.deque):
+    while dangling_whitespace_run:
+        old_line = dangling_whitespace_run.popleft()
+        result.append(old_line)

--- a/better_diff/unified_plus.py
+++ b/better_diff/unified_plus.py
@@ -77,11 +77,13 @@ def format_diff(a: str, b: str, fromfile: str = "a", tofile: str = "b") -> str:
 
 
 def _highlight_dangling_whitespace(result, last_line, line):
+    """Insert a highlight line for dangling whitespace."""
     highlight = "^" * (len(last_line) - len(last_line.rstrip()))
     result.append("?" + " " * (len(line) - 1) + highlight)
 
 
-def _dump_dangling_whitespace_run(result: list, dangling_whitespace_run: collections.deque):
+def _dump_dangling_whitespace_run(result: list, dangling_whitespace_run: collections.deque) -> None:
+    """Dump the dangling whitespace run to the result."""
     while dangling_whitespace_run:
         old_line = dangling_whitespace_run.popleft()
         result.append(old_line)

--- a/tests/component/test_cases/case_with_missing_trailing_whitespace/expected.diff
+++ b/tests/component/test_cases/case_with_missing_trailing_whitespace/expected.diff
@@ -1,14 +1,16 @@
 --- a.txt
 +++ b.txt
 @@ -1,8 +1,6 @@
--Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor 
 ?                                                                              ^
 +Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
  nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 -Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
--fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+?                                                                               ^
 +Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+-fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in  
+?                                                                              ^^
 +fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
  culpa qui officia deserunt mollit anim id est laborum.
 -\ Newline at end of file

--- a/tests/component/test_cases/file_with_multiple_white_space_trims_in_a_row/a.txt
+++ b/tests/component/test_cases/file_with_multiple_white_space_trims_in_a_row/a.txt
@@ -1,0 +1,15 @@
+Lorem ipsum dolor sit amet, 
+consectetur adipiscing elit,  
+sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+
+Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut 
+aliquip ex ea commodo consequat. 
+
+Duis aute irure dolor in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur. 
+
+Excepteur sint occaecat cupidatat non proident,
+sunt in culpa qui officia 
+deserunt mollit anim id est laborum. 
+

--- a/tests/component/test_cases/file_with_multiple_white_space_trims_in_a_row/b.txt
+++ b/tests/component/test_cases/file_with_multiple_white_space_trims_in_a_row/b.txt
@@ -1,0 +1,15 @@
+Lorem ipsum dolor sit amet,
+consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur.
+
+Excepteur sint occaecat cupidatat non proident,
+sunt in culpa qui officia
+deserunt mollit anim id est laborum.
+

--- a/tests/component/test_cases/file_with_multiple_white_space_trims_in_a_row/expected.diff
+++ b/tests/component/test_cases/file_with_multiple_white_space_trims_in_a_row/expected.diff
@@ -1,0 +1,33 @@
+--- a.txt
++++ b.txt
+@@ -1,14 +1,14 @@
+-Lorem ipsum dolor sit amet, 
+?                           ^
++Lorem ipsum dolor sit amet,
+-consectetur adipiscing elit,  
+?                            ^^
++consectetur adipiscing elit,
+-sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+?                                                                  ^
++sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+ Ut enim ad minim veniam,
+-quis nostrud exercitation ullamco laboris nisi ut
+?                                                 ^
++quis nostrud exercitation ullamco laboris nisi ut
+-aliquip ex ea commodo consequat. 
+?                                ^
++aliquip ex ea commodo consequat.
+
+ Duis aute irure dolor in reprehenderit in voluptate
+-velit esse cillum dolore eu fugiat nulla pariatur.
+?                                                  ^
++velit esse cillum dolore eu fugiat nulla pariatur.
+
+ Excepteur sint occaecat cupidatat non proident,
+-sunt in culpa qui officia
+?                         ^
++sunt in culpa qui officia
+-deserunt mollit anim id est laborum. 
+?                                    ^
++deserunt mollit anim id est laborum.


### PR DESCRIPTION
### What does this Pull Request accomplish?

Currently, if there is is a run (grouping) of lines that have trailing whitespace, the highlighting code ignores/misses them.

### Why should this Pull Request be merged?

Turn the trailing whitespace highlighting up to 11 by using a queu to hold onto those lines and then unpack with the companion add line (without whitespace) + highlight the difference

### What testing has been done?

New snapshot tests
